### PR TITLE
Fix a typo in actions steps

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -283,7 +283,7 @@ runs:
           if [ "${{ inputs.macos-app-mode }}" != "" ]; then
             ARGS+=" --macos-app-mode=${{ inputs.macos-app-mode }}"
           fi
-          if [ "${{ imputs.macos-sign-identity }}" != "" ]; then
+          if [ "${{ inputs.macos-sign-identity }}" != "" ]; then
             ARGS+=" --macos-sign-identity=${{ inputs.macos-sign-identity }}"
           fi
           if [ "${{ inputs.macos-sign-notarization }}" != "" ]; then


### PR DESCRIPTION
It now fails with:

```
Nuitka/Nuitka-Action/main/action.yml (Line: 219, Col: 12): Unrecognized named-value: 'imputs'. Located at position 1 within expression: imputs.macos-sign-identity
```