### PR TITLE
Cache Nuitka build C artifacts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -138,6 +138,11 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Setup Environment Variables
+      shell: bash
+      run: |
+        echo "NUITKA_CACHE_DIR=${{ github.action_path }}/nuitka/cache" >> $GITHUB_ENV
+        echo "PYTHON_VERSION=$(python --version | awk '{print $2}' | cut -d '.' -f 1,2)" >> $GITHUB_ENV
     - name: Install Dependencies
       shell: bash
       run: |
@@ -151,6 +156,21 @@ runs:
         fi
 
         pip install "${repo_url}/@${{inputs.nuitka-version }}#egg=nuitka"
+    - name: Install ccache
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get install -y ccache
+        export PATH="/usr/lib/ccache:$PATH"
+    - name: Cache Nuitka cache directory
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.NUITKA_CACHE_DIR }}
+        key: ${{ runner.os }}-python-${{ env.PYTHON_VERSION }}-nuitka-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-python-${{ env.PYTHON_VERSION }}-
+          ${{ runner.os }}-python-
+          ${{ runner.os }}-
 
     - name: Build Executable (Windows)
       if: runner.os == 'Windows'

--- a/action.yml
+++ b/action.yml
@@ -161,7 +161,6 @@ runs:
       shell: bash
       run: |
         sudo apt-get install -y ccache
-        export PATH="/usr/lib/ccache:$PATH"
     - name: Cache Nuitka cache directory
       uses: actions/cache@v3
       with:


### PR DESCRIPTION
Using [`actions/cache@v3`](https://github.com/actions/cache), the artifacts from the Nuitka build process can be shared between workflow runs.

This PR adds steps to the workflow which: 
1. sets up the cache action by defining where to cache Nuitka artifacts
2. installs `ccache` on Linux using apt-get. This step is skipped on macOS and Windows because Nuitka installs `ccache` on those platforms.

Things to note:
- The `actions/cache` is setup to restore caches prioritizing this action's latest commit SHA, the python version, then the runner's operating system.
- This PR's action has been tested on [my own testing repository](https://github.com/martinmiglio/nuitka-action-testing/actions/runs/5205306147) with a matrix of Python 3.7 to 3.11 on macOS, ubuntu, and windows runners.