### PR TITLE
fix typos in code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Similar to the others, but with `enable-plugins: pyside6` or `enable-plugins:tk-
 ensure that those libraries are included correctly.
 
 ```yaml
-- Name: Qt GUI with Pyside6
+- name: Qt GUI with Pyside6
   uses: Nuitka/Nuitka-Action@main
   with:
     nuitka-version: main
@@ -118,7 +118,7 @@ ensure that those libraries are included correctly.
 ```
 
 ```yaml
-- Name: Python GUI With Tkinter
+- name: Python GUI With Tkinter
   uses: Nuitka/Nuitka-Action@main
   with:
     nuitka-version: main
@@ -159,7 +159,7 @@ jobs:
         run: |
           pip install -r requirements.txt -r requirements-dev.txt
 
-      - Name: Build Executable
+      - name: Build Executable
         uses: Nuitka/Nuitka-Action@main
         with:
           nuitka-version: main


### PR DESCRIPTION
I am currently setting up a workflow to build binaries when we release a new version and I noticed three typos in your examples so here's a fix for them! :)