### PR TITLE
fix: syntax error for macos bundle if logic

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -373,7 +373,7 @@ runs:
           ARGS+=" --disable-cache=${{ inputs.disable-cache }}"
         fi
         if [ ${{ runner.os }} == 'macOS' ]; then
-          if [ "${{ inputs.macos-create-app-bundle }}" == "true" || "${{ inputs.disable-console }}" == "${{ true }}" ]; then
+          if [ "${{ inputs.macos-create-app-bundle }}" == "true" ] || [ "${{ inputs.disable-console }}" == "${{ true }}" ]; then
             ARGS+=" --macos-create-app-bundle"
           fi
           if [ "${{ inputs.macos-app-icon }}" != "" ]; then


### PR DESCRIPTION
The purpose of this pull request (PR) is to address and fix a syntax error that prevents --macos-create-app-bundle from being added to the arguments.

