### PR TITLE
fix(action): ensure UTF-8 for inputs on Windows runners 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -688,11 +688,13 @@ runs:
 
     - name: Build with Nuitka
       shell: bash
+      env:
+        PYTHONUTF8: 1
       run: |
         set -e
 
         # Prepare the JSON string for Nuitka, filtering out action-specific keys using Python
-        NUITKA_WORKFLOW_INPUTS=$(echo '${{ toJson(inputs) }}' | python -c "import sys, json; data = json.load(sys.stdin); [data.pop(k, None) for k in ['nuitka-version', 'working-directory', 'access-token', 'disable-cache', 'caching-key']]; json.dump(data, sys.stdout)")
+        NUITKA_WORKFLOW_INPUTS=$(echo '${{ toJson(inputs) }}' | python -c "import sys, json; data = json.load(sys.stdin); [data.pop(k, None) for k in ['nuitka-version', 'working-directory', 'access-token', 'disable-cache', 'caching-key']]; json.dump(data, sys.stdout, ensure_ascii=False)")
 
         # Pass the filtered JSON to Nuitka via an environment variable
         export NUITKA_WORKFLOW_INPUTS

--- a/action.yml.j2
+++ b/action.yml.j2
@@ -157,11 +157,13 @@ runs:
 
     - name: Build with Nuitka
       shell: bash
+      env:
+        PYTHONUTF8: 1
       run: |
         set -e
 
         # Prepare the JSON string for Nuitka, filtering out action-specific keys using Python
-        NUITKA_WORKFLOW_INPUTS=$(echo '${{ toJson(inputs) }}' | python -c "import sys, json; data = json.load(sys.stdin); [data.pop(k, None) for k in ['nuitka-version', 'working-directory', 'access-token', 'disable-cache', 'caching-key']]; json.dump(data, sys.stdout)")
+        NUITKA_WORKFLOW_INPUTS=$(echo '${{ toJson(inputs) }}' | python -c "import sys, json; data = json.load(sys.stdin); [data.pop(k, None) for k in ['nuitka-version', 'working-directory', 'access-token', 'disable-cache', 'caching-key']]; json.dump(data, sys.stdout, ensure_ascii=False)")
 
         # Pass the filtered JSON to Nuitka via an environment variable
         export NUITKA_WORKFLOW_INPUTS


### PR DESCRIPTION
On Windows, workflow inputs containing non-ASCII characters (e.g., Japanese in the `copyright` string) would cause the build to fail with a `UnicodeEncodeError`.

The failure occurred in Nuitka's post-processing step when creating Windows version resources. The root cause was the `echo | python` pipeline in `action.yml`, where Python would read `stdin` using the system's default codepage, corrupting the UTF-8 JSON stream and creating invalid surrogate characters.

This is fixed by setting the `PYTHONUTF8=1` environment variable for the script that processes the inputs. This forces Python to use UTF-8 for its standard streams, correctly decoding the input and preventing the error.

Additionally, `json.dump` is now called with `ensure_ascii=False` for better readability and robustness of the intermediate environment variable.

Before fix: https://github.com/chenmozhijin/LDDC/actions/runs/15503223326/job/43654332295
After fix: https://github.com/chenmozhijin/LDDC/actions/runs/15503442237/job/43654882183