### PR TITLE
Fix: include inputs.caching-key in restore keys for proper cache restoration

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -725,8 +725,7 @@ runs:
         key: nuitka-${{ inputs.caching-key }}-${{ runner.os }}-${{ runner.arch }}-python-${{ env.PYTHON_VERSION }}-nuitka-${{ github.sha }}
         restore-keys: |
           nuitka-${{ inputs.caching-key }}-${{ runner.os }}-${{ runner.arch }}-python-${{ env.PYTHON_VERSION }}-
-          nuitka-${{ runner.os }}-${{ runner.arch }}-python-${{ env.PYTHON_VERSION }}-
-          nuitka-${{ runner.os }}-${{ runner.arch }}-
+          nuitka-${{ inputs.caching-key }}-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Build with Nuitka
       shell: bash

--- a/action.yml.j2
+++ b/action.yml.j2
@@ -155,8 +155,7 @@ runs:
         key: nuitka-${{ inputs.caching-key }}-${{ runner.os }}-${{ runner.arch }}-python-${{ env.PYTHON_VERSION }}-nuitka-${{ github.sha }}
         restore-keys: |
           nuitka-${{ inputs.caching-key }}-${{ runner.os }}-${{ runner.arch }}-python-${{ env.PYTHON_VERSION }}-
-          nuitka-${{ runner.os }}-${{ runner.arch }}-python-${{ env.PYTHON_VERSION }}-
-          nuitka-${{ runner.os }}-${{ runner.arch }}-
+          nuitka-${{ inputs.caching-key }}-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Build with Nuitka
       shell: bash


### PR DESCRIPTION
This PR fixes an issue in action.yml where inputs.caching-key was missing from the cache restore-keys.
Without it, cache restoration could fail to match the primary cache key, leading to unnecessary rebuilds.

The change adds inputs.caching-key to the restore-keys to ensure consistency with the main cache key and improve cache reuse across runs.

## Summary by Sourcery

Fix cache restore-keys in action.yml to include inputs.caching-key for consistent cache matching and reuse

Bug Fixes:
- Include inputs.caching-key in restore-keys to ensure proper cache restoration

CI:
- Add inputs.caching-key to secondary cache restore keys in action.yml