### PR TITLE
Step up `actions/cache` from `v4` to `v5`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -719,7 +719,7 @@ runs:
         sudo apt-get install -y ccache
     - name: Cache Nuitka cache directory
       if: ${{ !inputs.disable-cache }}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ env.NUITKA_CACHE_DIR }}
         key: nuitka-${{ inputs.caching-key }}-${{ runner.os }}-${{ runner.arch }}-python-${{ env.PYTHON_VERSION }}-nuitka-${{ github.sha }}

--- a/action.yml.j2
+++ b/action.yml.j2
@@ -149,7 +149,7 @@ runs:
         sudo apt-get install -y ccache
     - name: Cache Nuitka cache directory
       if: ${{ !inputs.disable-cache }}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ env.NUITKA_CACHE_DIR }}
         key: nuitka-${{ inputs.caching-key }}-${{ runner.os }}-${{ runner.arch }}-python-${{ env.PYTHON_VERSION }}-nuitka-${{ github.sha }}


### PR DESCRIPTION
This should help fix the deprecation notices.

See https://github.com/gridhead/gi-loadouts/actions/runs/25470660658

<img width="980" height="1068" alt="image" src="https://github.com/user-attachments/assets/e331856e-e9c6-47e5-b200-8dbd6a14fb60" />

See https://github.com/gridhead/gi-loadouts/actions/runs/25473287651

<img width="980" height="1068" alt="image" src="https://github.com/user-attachments/assets/788d497e-ca0b-4545-99f3-f9d3c19a408c" />

## Summary by Sourcery

CI:
- Bump actions/cache used for Nuitka cache step from v4 to v5 in the workflow and its template.