### PR TITLE
Pin `actions/cache` to full commit SHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -719,7 +719,7 @@ runs:
         sudo apt-get install -y ccache
     - name: Cache Nuitka cache directory
       if: ${{ !inputs.disable-cache }}
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ env.NUITKA_CACHE_DIR }}
         key: nuitka-${{ inputs.caching-key }}-${{ runner.os }}-${{ runner.arch }}-python-${{ env.PYTHON_VERSION }}-nuitka-${{ github.sha }}


### PR DESCRIPTION
Nuitka-Action is a composite action that pulls down other actions. When Nuitka-Action is used in a repo that requires pinning actions to full commit SHAs, the transitive dependency on `actions/cache` still triggers the SHA validation and prevents the workflow from running.

This change pins the `actions/cache` workflow to the most recent version at the time of this writing (v5.0.5).

See: https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions

## Summary by Sourcery

Build:
- Pin the actions/cache usage in the composite action to commit 27d5ce7f107fe9357f9df03efb73ab90386fccae (v5.0.5) instead of the floating v5 tag.